### PR TITLE
Automatically enable HealthKit and Health Records capabilities in XCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSI
 
 If you would like to read clinical record data from the HealthKit store you will need to provide an extra variable during the plugin install.  The `CLINICAL_READ_PERMISSION` can be set to include the ability to read FHIR resources.  The value that is set here will be used in the `NSHealthClinicalHealthRecordsShareUsageDescription` key of your app's `info.plist` file.  It will be shown when your app asks for clinical record data from HealthKit.  Do not include the `CLINICAL_READ_PERMISSION` variable unless you really need access to the clinical record data otherwise Apple may reject your app.
 
-You will also need to manually check the `Health Records` capability for your app in Xcode under the HealthKit capability.
+The `Health Records` capability will be enabled if the `CLINICAL_READ_PERMISSION` is provided.
 
-Here is an install example with `CLINICAL_READ_PERMISSION` - 
+Here is an install example with `CLINICAL_READ_PERMISSION` -
 ```bash
 cordova plugin add com.telerik.plugins.healthkit --variable HEALTH_READ_PERMISSION='App needs read access' --variable HEALTH_WRITE_PERMISSION='App needs write access' --variable CLINICAL_READ_PERMISSION='App needs read access' --save
 ```
@@ -91,7 +91,7 @@ PhoneGap Build has [recently migrated](https://blog.phonegap.com/phonegap-7-0-1-
     <plugin name="com.telerik.plugins.healthkit" spec="^0.5.5" >
         <variable name="HEALTH_READ_PERMISSION" value="App needs read access" />
         <variable name="HEALTH_WRITE_PERMISSION" value="App needs write access" />
-    </plugin>        
+    </plugin>
 </platform>
 ```
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -57,8 +57,16 @@
       <true/>
     </config-file>
 
+    <config-file target="*/Entitlements-Debug.plist" parent="com.apple.developer.healthkit.access">
+      <array/>
+    </config-file>
+
     <config-file target="*/Entitlements-Release.plist" parent="com.apple.developer.healthkit">
       <true/>
+    </config-file>
+
+    <config-file target="*/Entitlements-Release.plist" parent="com.apple.developer.healthkit.access">
+      <array/>
     </config-file>
 
     <header-file src="src/ios/WorkoutActivityConversion.h"/>

--- a/scripts/after-plugin-install.js
+++ b/scripts/after-plugin-install.js
@@ -46,14 +46,26 @@ module.exports = function (ctx) {
 
     fs.writeFileSync(projPath, xcodeProj.writeSync());
 
-    // add CLINICAL_READ_PERMISSION text to config.xml
+    // enable health records
     var tagPlatform = etree.findall('./platform[@name="ios"]');
     if (tagPlatform.length > 0) {
+      // add CLINICAL_READ_PERMISSION text to config.xml
       var tagEditConfig = et.Element('config-file', { target: '*-Info.plist', parent: 'NSHealthClinicalHealthRecordsShareUsageDescription' });
       var tagString = et.Element('string');
       tagString.text = usageDescription;
       tagEditConfig.append(tagString);
       tagPlatform[0].append(tagEditConfig);
+
+      // add Health Records to entitlements
+      ['*Entitlements-Debug.plist', '*Entitlements-Release.plist'].forEach(function(fileName){
+        var healthRecordCapabilityConfig = et.Element('config-file', { target: fileName, parent: 'com.apple.developer.healthkit.access'});
+        var healthRecordArray = et.Element('array');
+        var healthRecordString = et.Element('string');
+        healthRecordString.text = 'health-records';
+        healthRecordArray.append(healthRecordString);
+        healthRecordCapabilityConfig.append(healthRecordArray);
+        tagPlatform[0].append(healthRecordCapabilityConfig);
+      });
 
       configData = etree.write({ 'indent': 4 });
       fs.writeFileSync(configXMLPath, configData);


### PR DESCRIPTION
These changes eliminate the need to manually enable healthkit-related capabilities in XCode by adding required entries to the entitlements files